### PR TITLE
Small fix for custom channel feature

### DIFF
--- a/pChat/i18n/en.lua
+++ b/pChat/i18n/en.lua
@@ -429,6 +429,7 @@ local strings = {
 	PCHAT_RESTOREPREFIX = "Add prefix to restored messages",
 	PCHAT_RESTOREPREFIXTT = "Add a prefix \'[H]\' to restored messages in order to easily see they were restored.\nThis will affect the current chat only after a reloadUI!\nThe color of the prefix will be shown with the standard ESO chat channel colors.",
 
+	PCHAT_BUILT_IN_CHANNEL_SWITCH_WARNING = "Cannot use existing built-in switch '%s'",
 	PCHAT_DUPLICATE_CHANNEL_SWITCH_WARNING = "Tried to replace already existing switch '%s'"
 }
 


### PR DESCRIPTION
The handling of built in switches was not working as expected and there was also a bug where it would look for the switches in the isOriginal table directly instead of the subtable for a channelId.