### PR TITLE
Update ChatMentions to fix font color bug.

### DIFF
--- a/pChat/MessageFormatters.lua
+++ b/pChat/MessageFormatters.lua
@@ -820,9 +820,9 @@ function pChat.InitializeMessageFormatters()
             db.LineStrings[db.lineNumber].rawValue = ""
         end
 
-        -- Coorbin20200708
+		-- Coorbin20200708
         -- Chat Mentions: username highlighting, audible ding, exclamation icon, etc.
-        text = pChat.cm_format(text, fromDisplayName, isCS)
+        text = pChat.cm_format(text, fromDisplayName, isCS, rcol)
 
         local linkedText = text
 


### PR DESCRIPTION
This fixes the issue related to the font color bug with ChatMentions. I tested this with both "ESO system colors" and "pChat custom colors" for channels with some custom colors I've set. 