### PR TITLE
Fix whole word matching with symbols.

### DIFF
--- a/pChat/ChatMentions.lua
+++ b/pChat/ChatMentions.lua
@@ -103,7 +103,7 @@ function pChat.cm_convertRGBToHex(r, g, b)
 end
 
 function pChat.cm_containsWholeWord(input, word)
-	local rxWord = "^" .. word .. "$"
+	local rxWord = "^%p*" .. word .. "%p*$"
 	local words = pChat.cm_dumbSplit(input)
 	for k,v in ipairs(words) do
 		if string.match(v, rxWord) ~= nil then


### PR DESCRIPTION
There was an edge case I found when "whole word" matching was enabled in ChatMentions, where it wouldn't ping you if there was punctuation on your name. I've fixed that now.