### PR TITLE
Added a separator (ASCII 0x20, Space) between the history prefix and messages.

### DIFF
--- a/pChat/ChatHistory.lua
+++ b/pChat/ChatHistory.lua
@@ -186,7 +186,7 @@ function pChat.InitializeChatHistory()
                                             if restoredChatRawText and restoredChatRawText ~= "" then
                                                 if db.addHistoryRestoredPrefix == true then
                                                     --If the message was restored from history then add a prefix [H] )for history) to it!
-                                                    restoredChatRawText = restoredPrefix .. restoredChatRawText
+                                                    restoredChatRawText = restoredPrefix .. " " .. restoredChatRawText
                                                 end
                                                 ChatSys.containers[containerIndex]:AddEventMessageToWindow(ChatSys.containers[containerIndex].windows[tabIndex], pChat.AddLinkHandler(restoredChatRawText, channelToRestore, historyIndex), category)
                                                 -- TODO why is this commented out?


### PR DESCRIPTION
Dear Developers,

Thank you very much for the awesome project!

---

Added a simple separator between the history prefix ("[H]", as of 2023-08) and a message:
```asm
From: "[H]Ineffably marvelous Universe...";
  To: "[H] Ineffably marvelous Universe...".
```

---

Farewell, dear Heroes!

Best and kind regards ✨ 