### PR TITLE
Refresh visibility of keyboard chat

### DIFF
--- a/pChat/ChatConfig.lua
+++ b/pChat/ChatConfig.lua
@@ -149,6 +149,8 @@ function pChat.InitializeChatConfig()
         end
         KEYBOARD_CHAT_SYSTEM:SetMinAlpha(chatTransparencyWhileminimize / 100)
 
+        KEYBOARD_CHAT_SYSTEM:RefreshVisibility()
+
         --Compatibility for PerfectPixel
         if PP ~= nil and PP.UpdateBackgrounds ~= nil then
             PP:UpdateBackgrounds('ChatWindow')


### PR DESCRIPTION
This prevents the keyboard and gamepad chat from showing at the same time upon every login
when you turn `OPTIONS > GAMEPLAY > USE KEYBOARD CHAT` off.