### PR TITLE
Fix for bug #10 described in pChat.lua

### DIFF
--- a/pChat/MessageFormatters.lua
+++ b/pChat/MessageFormatters.lua
@@ -625,7 +625,7 @@ function pChat.InitializeMessageFormatters()
         local startColortag = ""
 
         local preventLoops = 0
-        local maxLoops = 50 -- Increased further to handle complex messages
+        local maxLoops = 100 -- This is the max count of items you can deconstruct at a time as well, so in theory, you could use MAX_ITEM_SLOTS_PER_DECONSTRUCTION as the constant here.
         local colorizedText = true
         local newText = ""
 

--- a/pChat/MessageFormatters.lua
+++ b/pChat/MessageFormatters.lua
@@ -625,20 +625,32 @@ function pChat.InitializeMessageFormatters()
         local startColortag = ""
 
         local preventLoops = 0
+        local maxLoops = 50 -- Increased further to handle complex messages
         local colorizedText = true
         local newText = ""
 
-        while stillToParseCol do
+        -- Add safety check for empty or invalid input
+        if not rawText or rawTextlen == 0 then
+            return text
+        end
 
+        while stillToParseCol do
             -- Prevent infinite loops while its still in beta
-            if preventLoops > 10 then
+            if preventLoops > maxLoops then
+                -- If we hit the limit, return the remaining text as-is
+                if start <= rawTextlen then
+                    local remaining = string.sub(rawText, start)
+                    newText = newText .. remaining
+                end
+                logger:Debug(strfor("Hit loop prevention limit at position %d of %d while processing message: %s", start, rawTextlen, string.sub(text, 1, 100) .. "..."))
                 stillToParseCol = false
-            else
-                preventLoops = preventLoops + 1
+                break
             end
+            preventLoops = preventLoops + 1
 
             -- Handling Colors, search for color tag
             local startcol, endcol = string.find(rawText, "|[cC]%x%x%x%x%x%x(.-)|r", start)
+
             -- Not Found
             if startcol == nil then
                 startColortag = ""
@@ -646,34 +658,39 @@ function pChat.InitializeMessageFormatters()
                 stillToParseCol = false
                 newText = newText .. AddLinkHandlerToString(textToCheck, numLine, chanCode)
             else
-                startColortag = string.sub(rawText, startcol, startcol + 7)
-                -- pChat format all strings
-                if start == startcol then
-                    -- textToCheck is only (.-)
-                    textToCheck = string.sub(rawText, (startcol + 8), (endcol - 2))
-                    -- Change our start -> pos of (.-)
-                    start = endcol + 1
-                    newText = newText .. startColortag .. AddLinkHandlerToString(textToCheck, numLine, chanCode) .. "|r"
+                -- Add safety check for malformed color tags
+                if endcol and endcol <= rawTextlen then
+                    startColortag = string.sub(rawText, startcol, startcol + 7)
+                    -- pChat format all strings
+                    if start == startcol then
+                        -- textToCheck is only (.-)
+                        textToCheck = string.sub(rawText, (startcol + 8), (endcol - 2))
+                        -- Change our start -> pos of (.-)
+                        start = endcol + 1
+                        newText = newText .. startColortag .. AddLinkHandlerToString(textToCheck, numLine, chanCode) .. "|r"
 
-                    -- Do we need to continue ?
-                    if endcol == rawTextlen then
-                        -- We're at the end
-                        stillToParseCol = false
+                        -- Do we need to continue ?
+                        if endcol == rawTextlen then
+                            -- We're at the end
+                            stillToParseCol = false
+                        end
+                    else
+                        -- We will check colorized text at next loop
+                        textToCheck = string.sub(rawText, start, startcol - 1)
+                        start = startcol
+                        -- Tag color found but need to check some strings before
+                        newText = newText .. AddLinkHandlerToString(textToCheck, numLine, chanCode)
                     end
-
                 else
-                    -- We will check colorized text at next loop
-                    textToCheck = string.sub(rawText, start, startcol-1)
-                    start = startcol
-                    -- Tag color found but need to check some strings before
+                    -- Handle malformed tags by treating remaining text as non-colored
+                    textToCheck = string.sub(rawText, start)
+                    stillToParseCol = false
                     newText = newText .. AddLinkHandlerToString(textToCheck, numLine, chanCode)
                 end
             end
-
         end
 
         return newText
-
     end
 
 


### PR DESCRIPTION
I increased the maxLoops to 50 and added more safety checks.
This allowed for the string to be fully printed.
```Lua
    d(
        "|c0b610bYou craft |r|t16:16:/esoui/art/icons/crafting_smith_plug_standard_r_001.dds|t |H1:item:6000:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h[Dwarven Ingot]|h |cFFFFFFx33|r|c0b610b,|r |t16:16:/esoui/art/icons/crafting_ore_base_ebony_r3.dds|t |H1:item:6001:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h[Ebony Ingot]|h |cFFFFFFx232|r|c0b610b,|r |t16:16:/esoui/art/icons/crafting_ore_base_iron_r3.dds|t |H1:item:23107:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h[Orichalcum Ingot]|h |cFFFFFFx12|r|c0b610b,|r |t16:16:/esoui/art/icons/crafting_ore_base_iron_r2.dds|t |H1:item:5413:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h[Iron Ingot]|h |cFFFFFFx134|r|c0b610b,|r |t16:16:/esoui/art/icons/crafting_ore_base_high_iron_r3.dds|t |H1:item:4487:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h[Steel Ingot]|h |cFFFFFFx83|r|c0b610b,|r |t16:16:/esoui/art/icons/crafting_colossus_iron.dds|t |H1:item:64489:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h[Rubedite Ingot]|h |cFFFFFFx91|r|c0b610b,|r |t16:16:/esoui/art/icons/crafting_wood_base_oak_r3.dds|t |H1:item:533:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h[Sanded Oak]|h |cFFFFFFx91|r|c0b610b,|r |t16:16:/esoui/art/icons/crafting_ingot_voidstone.dds|t |H1:item:46130:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h[Voidstone Ingot]|h |cFFFFFFx58|r|c0b610b,|r |t16:16:/esoui/art/icons/crafting_ingot_moonstone.dds|t |H1:item:46129:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h[Quicksilver Ingot]|h |cFFFFFFx44|r|c0b610b,|r |t16:16:/esoui/art/icons/crafting_ingot_galatite.dds|t |H1:item:46128:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h[Galatite Ingot]|h |cFFFFFFx73|r|c0b610b.|r")

```
![image](https://github.com/user-attachments/assets/0955a978-4cee-455e-b8f2-b112a52d49d3)
