### PR TITLE
fix for collectible links copied from chat

### DIFF
--- a/pChat/AutomatedMessages.lua
+++ b/pChat/AutomatedMessages.lua
@@ -62,9 +62,13 @@ function pChat.InitializeAutomatedMessages()
 
             -- param1 : itemID
             -- Need to get
-            if linkType == ITEM_LINK_TYPE or linkType == COLLECTIBLE_LINK_TYPE then
+            if linkType == ITEM_LINK_TYPE then
                 -- Fakelink and GetItemLinkName
                 return "[" .. zo_strformat(SI_TOOLTIP_ITEM_NAME, GetItemLinkName("|H" .. linkStyle ..":" .. data .. "|h|h")) .. "]"
+            elseif linkType == COLLECTIBLE_LINK_TYPE then
+                local collectibleId = GetCollectibleIdFromLink(fullLink)
+                local collectibleName = GetCollectibleInfo(collectibleId)
+                return "[" .. zo_strformat(SI_COLLECTIBLE_NAME_FORMATTER, collectibleName) .. "]"
                     -- param1 : achievementID
             elseif linkType == ACHIEVEMENT_LINK_TYPE then
                 -- zo_strformat to avoid masculine/feminine problems


### PR DESCRIPTION
--#9    2020-07-20 Marazota Collectibles linked into chat will not show properly the collectible's link
--link collectibles to chat (especially that one from "Not Collected") + add any word.
--Then right click the message and copy it. The link will be empty (only []shown)

![image](https://github.com/user-attachments/assets/81f631d2-6768-4b90-b794-c57f75483fc6)

copied text
[Abyssal Tea Set][Any Race, Any Alliance][Aramril's Training][Ascendant Outfit Style][Class: Arcanist]