### PR TITLE
Fix nil value errors in ChatCopyOptions:ShowSearchUI

### DIFF
--- a/pChat/CopyHandler.lua
+++ b/pChat/CopyHandler.lua
@@ -1309,6 +1309,7 @@ function ChatCopyOptions:Initialize(control)
         self:InitializeFilterButtons(control)
         self:InitializeGuildFilters(control)
         self.filteredChannels = {}
+        self.openedSearchUICount = 0
 
         self:InitializeSearchUI(control)
 
@@ -1915,8 +1916,17 @@ function ChatCopyOptions:ChangeFiltersState(doEnable, filterType)
 end
 
 function ChatCopyOptions:ShowSearchUI(searchTerm)
+    -- Ensure initialization if not already done
+    if not self.initialized and self.control then
+        self:Initialize(self.control)
+    end
+
+    if not self.searchUIToggleButton or not self.searchUI or not self.control then
+        return
+    end
+
     self.isSearchUIShown = true
-    self.openedSearchUICount = self.openedSearchUICount + 1
+    self.openedSearchUICount = (self.openedSearchUICount or 0) + 1
 
     self.searchUIToggleButton:SetText(GetString(PCHAT_TOGGLE_SEARCH_UI_OFF))
     --d("[pChat]ChatCopyOptions-SearchUI - SHOWN")


### PR DESCRIPTION
Fixed two issues that caused errors when opening the search UI:

1. openedSearchUICount was nil when incrementing, causing "operator + is 
   not supported for nil + number" error. Now properly initialized to 0 
   in Initialize() and added nil-safe increment in ShowSearchUI().

2. searchUIToggleButton and other UI elements were nil when ShowSearchUI 
   was called before dialog initialization completed. Added initialization 
   check and nil guards to ensure UI elements exist before use.

Fixes errors:
- CopyHandler.lua:1919: operator + is not supported for nil + number
- CopyHandler.lua:1922: attempt to index a nil value